### PR TITLE
Help repo from abandonment of gin-gonic/contrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ $ go get github.com/utrack/gin-csrf
 import (
     "errors"
     
-    "github.com/gin-gonic/gin"
-    "github.com/gin-gonic/contrib/sessions"
+    "github.com/gin-contrib/sessions"
     "github.com/utrack/gin-csrf"
+    "gopkg.in/gin-gonic/gin.v1"
 )
 
 func main(){

--- a/csrf.go
+++ b/csrf.go
@@ -7,8 +7,8 @@ import (
 	"io"
 
 	"github.com/dchest/uniuri"
-	"github.com/gin-gonic/contrib/sessions"
-	"github.com/gin-gonic/gin"
+	"github.com/gin-contrib/sessions"
+	"gopkg.in/gin-gonic/gin.v1"
 )
 
 const (

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gin-gonic/contrib/sessions"
-	"github.com/gin-gonic/gin"
+	"github.com/gin-contrib/sessions"
+	"gopkg.in/gin-gonic/gin.v1"
 )
 
 func init() {


### PR DESCRIPTION
[This announcement][an] says the `sessions` package is abandoned.  So I rewrite to import from the new URL.

* from: `github.com/gin-gonic/contrib/sessions`
* to: `github.com/gin-contrib/sessions`

[an]: https://github.com/gin-gonic/contrib/tree/master/sessions

And we should use gopkg instead of github to import gin because the new `sessions` use the new one.  Also I changed for that.

* from: `github.com/gin-gonic/gin`
* to: `gopkg.in/gin-gonic/gin.v1`