### PR TITLE
Csrf protecct on session lost, csrf salt per session

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -100,7 +100,7 @@ func Middleware(options Options) gin.HandlerFunc {
 		s, ok := session.Get(csrfSalt).(string)
 
 		if !ok || len(s) == 0 {
-			c.Next()
+			errorFunc(c)
 			return
 		}
 

--- a/csrf.go
+++ b/csrf.go
@@ -106,8 +106,6 @@ func Middleware(options Options) gin.HandlerFunc {
 
 		salt = s
 
-		session.Delete(csrfSalt)
-
 		token := tokenGetter(c)
 
 		if tokenize(options.Secret, salt) != token {
@@ -128,10 +126,13 @@ func GetToken(c *gin.Context) string {
 		return t.(string)
 	}
 
-	salt := uniuri.New()
+	salt, ok := session.Get(csrfSalt).(string)
+	if ! ok {
+		salt := uniuri.New()
+		session.Set(csrfSalt, salt)
+		session.Save()
+	}
 	token := tokenize(secret, salt)
-	session.Set(csrfSalt, salt)
-	session.Save()
 	c.Set(csrfToken, token)
 
 	return token


### PR DESCRIPTION

1. Do not pass the csrf check if the session is lost.
2.  The csrf salt should be created per session instead of per request. Otherwise it will invalidate the token of current page if the user open another tab page of the same site.