### PR TITLE
Add new option to ingore some specific paths

### DIFF
--- a/csrf_test.go
+++ b/csrf_test.go
@@ -230,6 +230,102 @@ func TestIgnoreMethods(t *testing.T) {
 	}
 }
 
+// In this scenario we want to check CSRF token for all the POST requests,
+// except, for example, "/paypal/notify" (which is endpoint that PayPal calls during
+// a payment validation) and "/hpkp/report" (which URL where Public-Key-Pins validation failures are reported)
+func TestIgnorePaths(t *testing.T) {
+
+	var token string
+
+	g := newServer(Options{
+		Secret:      "secret123",
+		IgnorePaths: []string{"/paypal/notify", "/hpkp/report"},
+		ErrorFunc: func(c *gin.Context) {
+			c.String(400, "CSRF token mismatch")
+			c.Abort()
+		},
+	})
+
+	g.GET("/login", func(c *gin.Context) {
+		token = GetToken(c)
+	})
+
+	g.POST("/form", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK") // post some usual form
+	})
+
+	g.POST("/paypal/notify", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK PP")
+	})
+
+	g.POST("/hpkp/report", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK HPKP")
+	})
+
+	// start session, generate token
+	r1 := request(g, requestOptions{URL: "/login"})
+	sessionCookies := r1.Header().Get("Set-Cookie")
+
+	// Experiment 1:
+	// call the /form two times and verify that it returns OK only if we send CSRF token, otherwise it fails
+	r2Ok := request(g, requestOptions{
+		Method: "POST",
+		URL:    "/form",
+		Headers: map[string]string{
+			"Cookie":       sessionCookies,
+			"X-XSRF-Token": token,
+		},
+	})
+
+	if body := r2Ok.Body.String(); body != "OK" {
+		t.Error("Response is not OK: ", body)
+	}
+
+	r2Failure := request(g, requestOptions{
+		Method: "POST",
+		URL:    "/form",
+		Headers: map[string]string{
+			"Cookie": sessionCookies,
+			// omitted CSRF token
+		},
+	})
+
+	if 400 != r2Failure.Code {
+		// we expect second request returns 400 because we omitted CSRF token
+		t.Error("Response is not 400: ", r2Failure.Code)
+	}
+
+	// Experiment 2:
+	// Even if we omitted the CSRF token for the POST request, it will be ignored
+	r3 := request(g, requestOptions{
+		Method: "POST",
+		URL:    "/paypal/notify",
+		Headers: map[string]string{
+			"Cookie": sessionCookies,
+			// omitted CSRF token
+		},
+	})
+
+	if body := r3.Body.String(); body != "OK PP" {
+		t.Error("Response is not OK: ", body)
+	}
+
+	// Experiment 3:
+	// The same as above, but with another path
+	r4 := request(g, requestOptions{
+		Method: "POST",
+		URL:    "/hpkp/report",
+		Headers: map[string]string{
+			"Cookie": sessionCookies,
+			// omitted CSRF token
+		},
+	})
+
+	if body := r4.Body.String(); body != "OK HPKP" {
+		t.Error("Response is not OK: ", body)
+	}
+}
+
 func TestTokenGetter(t *testing.T) {
 	var token string
 	g := newServer(Options{


### PR DESCRIPTION
Introduction
==========

Sometimes, some 3rd party service should send you some data in a POST request. For example, when you perform a payment using PayPal it calls your endpoint and sends you a validation data. As long as the request comes from another provider, you can't modify it and add some additional header or form parameter. In this case, you might want to protect with CSRF token all the POST requests, _except PayPal notification endpoint_

Implementation
============

I added one additional option `IgnorePaths` where you can specify the array of paths starting with a slash that could be ignored from CSRF checking. Say,

```
	router.Use(csrf.Middleware(csrf.Options{
		Secret:      "secret",
		IgnorePaths: []string{ "/paypal/notify" },
		ErrorFunc: func(c *gin.Context) {
			c.String(400, "CSRF token mismatch")
			c.Abort()
		},
	}))
```

Will protect all the POST requests expect `/paypal/notify` endpoint.