### PR TITLE
Revise usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,34 +13,38 @@ $ go get github.com/utrack/gin-csrf
 ## Usage
 
 ``` go
-import (
-    "errors"
+package main
 
-    "github.com/gin-gonic/gin"
-    "github.com/gin-contrib/sessions"
-    "github.com/utrack/gin-csrf"
+import (
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+	"github.com/utrack/gin-csrf"
 )
 
-func main(){
-    r := gin.Default()
-    store := sessions.NewCookieStore([]byte("secret"))
-    r.Use(sessions.Sessions("mysession", store))
-    r.Use(csrf.Middleware(csrf.Options{
-        Secret: "secret123",
-        ErrorFunc: func(c *gin.Context){
-            c.String(400, "CSRF token mismatch")
+func main() {
+	r := gin.Default()
+	store := cookie.NewStore([]byte("secret"))
+	r.Use(sessions.Sessions("mysession", store))
+	r.Use(csrf.Middleware(csrf.Options{
+		Secret: "secret123",
+		ErrorFunc: func(c *gin.Context) {
+			c.String(400, "CSRF token mismatch")
 			c.Abort()
-        },
-    }))
+		},
+	}))
 
-    r.GET("/protected", func(c *gin.Context){
-        c.String(200, csrf.GetToken(c))
-    })
+	r.GET("/protected", func(c *gin.Context) {
+		c.String(200, csrf.GetToken(c))
+	})
 
-    r.POST("/protected", func(c *gin.Context){
-        c.String(200, "CSRF token is valid")
-    })
+	r.POST("/protected", func(c *gin.Context) {
+		c.String(200, "CSRF token is valid")
+	})
+
+	r.Run(":8080")
 }
+
 ```
 
 [Gin]: http://gin-gonic.github.io/gin/


### PR DESCRIPTION
This PR should address the issue and close #14 
The usage example appeared to have some minor errors including:
- an unused stdlib import (errors)
- old implementation of session store which is no longer valid -> cookies sub package
- the gin engine is now run on port 8080 and blocks to serve requests instead of terminating

Hope this fix is helpful for anyone making use of the package 😎

Code is tested here: https://github.com/mikeee/demo_gin-csrf